### PR TITLE
update: showing bson ids correctly

### DIFF
--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -168,6 +168,14 @@ function stringifyArray(ary, options, level) {
   }
 };
 
+function parseBSONType(keys, object) {
+  if (~keys.indexOf('_bsontype'))
+    keys.forEach(function(k){
+      if (k != '_bsontype')
+        object[k] = object.toString();
+    });
+}
+
 // Convert an object to a string, such as {a: 1}.
 // This function calls stringify() for each of its values,
 // and does not output functions or prototype values.
@@ -178,6 +186,9 @@ function stringifyObject(obj, options, level) {
   var ws = pretty ? '\n' + new(Array)(level * 4 + 1).join(' ') : ' ';
 
   var keys = options.showHidden ? Object.keys(obj) : Object.getOwnPropertyNames(obj);
+
+  parseBSONType(keys, obj);
+
   keys.forEach(function (k) {
     if (Object.prototype.hasOwnProperty.call(obj, k)
         && !(obj[k] instanceof Function && options.hideFunctions)) {


### PR DESCRIPTION
Mongodb uses `bson objects` with `ObjectIds` ids. These `objects` contain a 24 digit hex number. This was shown like this e.g. `{ _bsontype: 'ObjectID', id: 'VÇDM­g*ë'}` and is now shown correctly e.g. `{ _bsontype: 'ObjectID', id: '56c74400004dad672a99eb8f' }` 